### PR TITLE
fix: Forestry previews

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.1",
   "license": "MIT",
   "scripts": {
-    "develop": "gatsby develop",
+    "develop": "gatsby develop -H 0.0.0.0 -p 8080",
     "start": "npm run develop",
     "build": "gatsby build --prefix-paths",
     "serve": "gatsby serve"


### PR DESCRIPTION
Forestry previews must run on `0.0.0.0:8080` because gatsby develop is run from within a container.

cc @olinares 